### PR TITLE
Improve execution speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Alternatively, to install from source:
      
 ## Running the CF Checker
 
-`cfchecks [-a|--area_types area_types.xml] [-s|--cf_standard_names standard_names.xml] [-v|--version CFVersion] file1 [file2...]`
+`cfchecks [-a area_types.xml] [-s standard_names.xml] [-t cache_time_days ] [-v CFVersion] [-x] [--cachedir <dir>] file1 [file2...]`
 
 ### Environment Variables
 

--- a/test_files/CF_1_0_OK.check
+++ b/test_files/CF_1_0_OK.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CF_1_0_OK.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/CF_1_7.check
+++ b/test_files/CF_1_7.check
@@ -2,8 +2,8 @@ CHECKING NetCDF FILE: CF_1_7.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.7
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
-Using Area Type Table Version 6 (22 February 2017)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
+Using Area Type Table Version 7 (14 March 2018)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 ERROR: (2.6.3): Variable external_var2 named as an external variable must not be present in this file

--- a/test_files/CRM018_test1.check
+++ b/test_files/CRM018_test1.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM018_test1.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 WARN: (2.6.1): No 'Conventions' attribute present

--- a/test_files/CRM021_test1.check
+++ b/test_files/CRM021_test1.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM021_test1.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/CRM024_test1.check
+++ b/test_files/CRM024_test1.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM024_test1.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 ERROR: (2.6.1): This netCDF file does not appear to contain CF Convention data.

--- a/test_files/CRM026_test2.check
+++ b/test_files/CRM026_test2.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM026_test2.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/CRM027_test1.check
+++ b/test_files/CRM027_test1.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM027_test1.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 WARN: (7.1): Data for variable time lies outside cell boundaries

--- a/test_files/CRM027_test2.check
+++ b/test_files/CRM027_test2.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM027_test2.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 WARN: (7.1): Data for variable time lies outside cell boundaries

--- a/test_files/CRM028_test1.check
+++ b/test_files/CRM028_test1.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM028_test1.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 WARN: (2.6.1): No 'Conventions' attribute present

--- a/test_files/CRM032_test1.check
+++ b/test_files/CRM032_test1.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM032_test1.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 ERROR: (2.6.1): This netCDF file does not appear to contain CF Convention data.

--- a/test_files/CRM033_test1.check
+++ b/test_files/CRM033_test1.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM033_test1.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 WARN: (2.6.1): No 'Conventions' attribute present

--- a/test_files/CRM035.check
+++ b/test_files/CRM035.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM035.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 WARN: (2.6.1): No 'Conventions' attribute present

--- a/test_files/CRM037.check
+++ b/test_files/CRM037.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM037.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/CRM038.check
+++ b/test_files/CRM038.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM038.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/CRM041.check
+++ b/test_files/CRM041.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: CRM041.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/GregRappa.check
+++ b/test_files/GregRappa.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: GregRappa.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/Trac020_test1.check
+++ b/test_files/Trac020_test1.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: Trac020_test1.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/Trac020_test2.check
+++ b/test_files/Trac020_test2.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: Trac020_test2.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/Trac022.check
+++ b/test_files/Trac022.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: Trac022.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 WARN: (2.6.1): No 'Conventions' attribute present

--- a/test_files/Trac049_test1.check
+++ b/test_files/Trac049_test1.check
@@ -2,8 +2,8 @@ CHECKING NetCDF FILE: Trac049_test1.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.4
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
-Using Area Type Table Version 6 (22 February 2017)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
+Using Area Type Table Version 7 (14 March 2018)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/Trac049_test2.check
+++ b/test_files/Trac049_test2.check
@@ -2,8 +2,8 @@ CHECKING NetCDF FILE: Trac049_test2.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.4
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
-Using Area Type Table Version 6 (22 February 2017)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
+Using Area Type Table Version 7 (14 March 2018)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/UpgradeVn.pl
+++ b/test_files/UpgradeVn.pl
@@ -14,9 +14,10 @@
 #           $standardNameVN as appropriate.
 #-------------------------------------------------------------------------- 
 $checkerVN="3.0.6-dev";
-$standardNameVN="49 (2018-02-13T08:44:33Z)";
+$standardNameVN="50 (2018-03-14T11:01:19Z)";
+$areaTypeVN="7 (14 March 2018)";
 
-$TEST_FILES_DIR="/home/ros/puma2/git-projects/cf-checker/test_files";
+$TEST_FILES_DIR="/home/ros/git-projects/cf-checker/test_files";
 chdir $TEST_FILES_DIR or die "Failed to cd to $TEST_FILES_DIR: $!\n";
 
 foreach $file (<*.check>) {
@@ -36,6 +37,8 @@ foreach $file (<*.check>) {
 	    } else {
 		push (@new_file, "Using Standard Name Table Version $standardNameVN\n");
 	    }
+        } elsif (/Using Area Type Table/) {
+            push (@new_file, "Using Area Type Table Version $areaTypeVN\n");
 	} else {
 	    push (@new_file, "$_");
 	}

--- a/test_files/badc_units.check
+++ b/test_files/badc_units.check
@@ -2,7 +2,7 @@
 CHECKING NetCDF FILE: badc_units.nc
 =====================
 Using CF Checker Version 3.0.6-dev
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 
 WARNING (7.1): Data for variable time lies outside cell boundaries
 

--- a/test_files/cell_measures.check
+++ b/test_files/cell_measures.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: cell_measures.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 ERROR: (7.1): Incorrect dimensions for boundary variable: lon_vertices

--- a/test_files/cell_methods.check
+++ b/test_files/cell_methods.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: cell_methods.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 ERROR: (7.1): Incorrect dimensions for boundary variable: lon_vertices

--- a/test_files/complex.check
+++ b/test_files/complex.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: complex.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 WARN: (2.6.1): No 'Conventions' attribute present

--- a/test_files/example_5.10.check
+++ b/test_files/example_5.10.check
@@ -2,8 +2,8 @@ CHECKING NetCDF FILE: example_5.10.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.7
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
-Using Area Type Table Version 6 (22 February 2017)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
+Using Area Type Table Version 7 (14 March 2018)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/example_6.2.check
+++ b/test_files/example_6.2.check
@@ -2,8 +2,8 @@ CHECKING NetCDF FILE: example_6.2.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.7
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
-Using Area Type Table Version 6 (22 February 2017)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
+Using Area Type Table Version 7 (14 March 2018)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/flag_tests.check
+++ b/test_files/flag_tests.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: flag_tests.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.3
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/formula_terms.check
+++ b/test_files/formula_terms.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: formula_terms.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 WARN: (7.1): Data for variable lat lies outside cell boundaries

--- a/test_files/hfogo_O1_labelVariable_KT.check
+++ b/test_files/hfogo_O1_labelVariable_KT.check
@@ -2,7 +2,7 @@ CHECKING NetCDF FILE: hfogo_O1_labelVariable_KT.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.0
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 

--- a/test_files/issue27.check
+++ b/test_files/issue27.check
@@ -2,8 +2,8 @@ CHECKING NetCDF FILE: issue27.nc
 =====================
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.6
-Using Standard Name Table Version 49 (2018-02-13T08:44:33Z)
-Using Area Type Table Version 6 (22 February 2017)
+Using Standard Name Table Version 50 (2018-03-14T11:01:19Z)
+Using Area Type Table Version 7 (14 March 2018)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 ERROR: (5): coordinates attribute referencing non-existent variable

--- a/test_files/stdName_test.check
+++ b/test_files/stdName_test.check
@@ -3,7 +3,7 @@ CHECKING NetCDF FILE: stdName_test.nc
 Using CF Checker Version 3.0.6-dev
 Checking against CF Version CF-1.7
 Using Standard Name Table Version 2 (2006-09-26T18:12:43Z)
-Using Area Type Table Version 6 (22 February 2017)
+Using Area Type Table Version 7 (14 March 2018)
 Using Standardized Region Name Table Version 2 (12 June 2013)
 
 WARN: (2.6.1): Inconsistency - This netCDF file appears to contain CF-1.0 data, but you've requested a validity check against CF-1.7

--- a/test_files/tests.sh
+++ b/test_files/tests.sh
@@ -9,7 +9,7 @@ mkdir $outdir
 std_name_table=http://cfconventions.org/Data/cf-standard-names/current/src/cf-standard-name-table.xml
 area_table=http://cfconventions.org/Data/area-type-table/current/src/area-type-table.xml
 
-cfchecker="/home/ros/puma2/dev/bin/cfchecks"
+cfchecker="/home/ros/software/dev/bin/cfchecks"
 
 failed=0
 
@@ -21,30 +21,31 @@ do
   if test $file == "badc_units.nc"
   then
     # Check --badc option (Note:  Need to set path to badc_units.txt in cfchecks.py)
-    $cfchecker --badc $file -s $std_name_table > $outdir/$file.out 2>&1
+    $cfchecker -x --badc $file -s $std_name_table > $outdir/$file.out 2>&1
   elif test $file == "stdName_test.nc"
   then
     # Check --cf_standard_names option
+    # Test uses an older version of standard_name table so don't use table caching
     $cfchecker -s ./stdName_test_table.xml -a $area_table $file > $outdir/$file.out 2>&1
   elif test $file == "CF_1_2.nc"
   then
     # CF-1.2
-    $cfchecker -s $std_name_table -v 1.2 $file > $outdir/$file.out 2>&1
+    $cfchecker -x -s $std_name_table -v 1.2 $file > $outdir/$file.out 2>&1
   elif test $file == "flag_tests.nc"
   then
     # CF-1.3
-    $cfchecker -s $std_name_table -v 1.3 $file > $outdir/$file.out 2>&1
+    $cfchecker -x -s $std_name_table -v 1.3 $file > $outdir/$file.out 2>&1
   elif [[ $file == "Trac049_test1.nc" || $file == "Trac049_test2.nc" ]]
   then 
     # CF-1.4
-    $cfchecker -s $std_name_table -a $area_table -v 1.4 $file > $outdir/$file.out 2>&1
+    $cfchecker -x -s $std_name_table -a $area_table -v 1.4 $file > $outdir/$file.out 2>&1
   elif [[ $file == "CF_1_7.nc" || $file == "example_6.2.nc" || $file == "example_5.10.nc" || $file = "issue27.nc" ]]
   then
     # Run checker using the CF version specified in the conventions attribute of the file
-    $cfchecker -s $std_name_table -v auto $file > $outdir/$file.out 2>&1
+    $cfchecker -x -s $std_name_table -v auto $file > $outdir/$file.out 2>&1
   else
     # Run the checker on the file
-    $cfchecker -s $std_name_table -v 1.0 $file > $outdir/$file.out 2>&1
+    $cfchecker -x -s $std_name_table -v 1.0 $file > $outdir/$file.out 2>&1
   fi
   # Check the output against what is expected
   result=${file%.nc}.check


### PR DESCRIPTION
Add option to cache standard name, area and region types tables using python shelve files.
Also options to set cache duration and directory in which to store the shelve files. 

See issue #35

Also update check files to new versions of tables
Update tests to use table caching