### PR TITLE
Needs future package to use past module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='cfchecker',
 
       include_package_data=True,
       zip_safe=False,
-      install_requires=['netCDF4', 'numpy>=1.7', 'cfunits>=3.0.0'],
+      install_requires=['netCDF4', 'numpy>=1.7', 'cfunits>=3.0.0', 'future'],
       entry_points={'console_scripts': ['cfchecks = cfchecker.cfchecks:main']},
       scripts=['src/cf-checker']
       )


### PR DESCRIPTION
The `cfchecks` reports an error:
```shell
$ cfchecks 
Traceback (most recent call last):
  File "/DATA/miniconda3/envs/cf-checker-python3/bin/cfchecks", line 6, in <module>
    from cfchecker.cfchecks import main
  File "/DATA/miniconda3/envs/cf-checker-python3/lib/python3.7/site-packages/cfchecker/cfchecks.py", line 51, in <module>
    from past.builtins import basestring
ModuleNotFoundError: No module named 'past'
```