### PR TITLE
Remove encode to ascii

### DIFF
--- a/src/cfchecker/cfchecks.py
+++ b/src/cfchecker/cfchecks.py
@@ -2327,7 +2327,7 @@ class CFChecker(object):
 
                       # Remove this line for python3??
                       # stdNameUnits is unicode which udunits can't deal with.  Explicity convert it to ASCII
-                      stdNameUnits=stdNameUnits.encode('ascii')
+                      # stdNameUnits=stdNameUnits.encode('ascii')
 
                       canonicalUnit = Units(stdNameUnits)
                       # To compare units we need to remove the reference time from the variable units


### PR DESCRIPTION
The cfunits package complains about using the ASCII encode for units:
```
Traceback (most recent call last):
  File "/DATA/miniconda3/envs/cf-checker-python3/bin/cfchecks", line 10, in <module>
    sys.exit(main())
  File "/DATA/miniconda3/envs/cf-checker-python3/lib/python3.7/site-packages/cfchecker/cfchecks.py", line 3087, in main
    inst.checker(file)
  File "/DATA/miniconda3/envs/cf-checker-python3/lib/python3.7/site-packages/cfchecker/cfchecks.py", line 530, in checker
    return self._checker()
  File "/DATA/miniconda3/envs/cf-checker-python3/lib/python3.7/site-packages/cfchecker/cfchecks.py", line 771, in _checker
    self.chkUnits(var,allCoordVars)
  File "/DATA/miniconda3/envs/cf-checker-python3/lib/python3.7/site-packages/cfchecker/cfchecks.py", line 2332, in chkUnits
    canonicalUnit = Units(stdNameUnits)
  File "/DATA/miniconda3/envs/cf-checker-python3/lib/python3.7/site-packages/cfunits/units.py", line 680, in __init__
    if ' since ' in units:
TypeError: a bytes-like object is required, not 'str'
```