### PR TITLE
Support file paths with spaces

### DIFF
--- a/src/cfchecker/cfchecks.py
+++ b/src/cfchecker/cfchecks.py
@@ -406,7 +406,6 @@ class CFChecker:
   def checker(self, file):
 
     self._init_results(file)
-    fileSuffix = re.compile('^\S+\.nc$')
 
     if self.uploader:
         realfile = string.split(file,".nc")[0]+".nc"
@@ -420,7 +419,7 @@ class CFChecker:
         print("=====================")
 
     # Check for valid filename
-    if not fileSuffix.match(file):
+    if not file.endswith('.nc'):
         self._fatal("Filename must have .nc suffix", code="2.1")
 
     # Read in netCDF file


### PR DESCRIPTION
Use `file.endswith('.nc')` to support file paths with spaces in them because the previous regex was too restrictive.

This branched off `python3`.