### PR TITLE
updated numpy.issubdtype checks to np.integer and np.floating

### DIFF
--- a/src/cfchecker/cfchecks.py
+++ b/src/cfchecker/cfchecks.py
@@ -1667,8 +1667,8 @@ class CFChecker(object):
             if is_str_or_basestring(var.getncattr(attribute)):
                 attr_type = 'S'
           
-            elif (numpy.issubdtype(attr_type, numpy.int) or
-                  numpy.issubdtype(attr_type, numpy.float) or
+            elif (numpy.issubdtype(attr_type, numpy.integer) or
+                  numpy.issubdtype(attr_type, numpy.floating) or
                   attr_type == numpy.ndarray):
                 attr_type = 'N'
 
@@ -2085,7 +2085,7 @@ class CFChecker(object):
 
             if is_str_or_basestring(value):
                 attrType = 'S'
-            elif numpy.issubdtype(attrType, numpy.int) or numpy.issubdtype(attrType, numpy.float):
+            elif numpy.issubdtype(attrType, numpy.integer) or numpy.issubdtype(attrType, numpy.floating):
                 attrType = 'N'
             elif attrType == numpy.ndarray:
                 attrType = 'N'


### PR DESCRIPTION
As shown in issue #87 the check for subtypes of integer and floating were OS-dependent before (32-bit v 64-bit) with numpy>1.19. This modification avoids issues where NetCDF attribute data types were not identified correctly.