### PR TITLE
Improve testing

### DIFF
--- a/.github/workflows/action-install.yml
+++ b/.github/workflows/action-install.yml
@@ -1,0 +1,70 @@
+# Install esmvalcore from PyPi on different OS's
+# and different Python version; test locally with
+# act: https://github.com/nektos/act
+# Example how to setup conda workflows:
+# https://github.com/marketplace/actions/setup-miniconda
+# Notes:
+#  - you can group commands with | delimiter (or &&) but those will be run
+#    in one single call; declaring the shell variable makes the action run each
+#    command separately (better for debugging);
+#  - can try multiple shells eg pwsh or cmd /C CALL {0} (but overkill for now!);
+# TODO: read the cron tasking documentation:
+# https://www.netiq.com/documentation/cloud-manager-2-5/ncm-reference/data/bexyssf.html
+
+name: PyPi Install
+
+# runs on a push on master and at the end of every day
+on:
+  # triggering on push without branch name will run tests everytime
+  # there is a push on any branch
+  # turn it on only if needed
+  push:
+    branches:
+    - master
+    # test before merge on a dev branch
+    # - ga_tests
+
+  # run the test only if the PR is to master
+  # turn it on if required
+  #pull_request:
+  #  branches:
+  #  - master
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  linux:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+      # fail-fast set to False allows all other tests
+      # in the worflow to run regardless of any fail
+      fail-fast: false
+    name: Linux Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: cfchecker
+          python-version: ${{ matrix.python-version }}
+          miniconda-version: "latest"
+          channels: conda-forge
+      - shell: bash -l {0}
+        run: mkdir -p pypi_install_linux_artifacts_python_${{ matrix.python-version }}
+      - shell: bash -l {0}
+        run: conda --version 2>&1 | tee pypi_install_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
+      - shell: bash -l {0}
+        run: python -V 2>&1 | tee pypi_install_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
+      - shell: bash -l {0}
+        run: pip install cfchecker 2>&1 | tee pypi_install_linux_artifacts_python_${{ matrix.python-version }}/install.txt
+      - shell: bash -l {0}
+        run: cfchecks --help
+      - shell: bash -l {0}
+        run: cfchecks --version 2>&1 | tee pypi_install_linux_artifacts_python_${{ matrix.python-version }}/version.txt
+      - name: Upload artifacts
+        if: ${{ always() }}  # upload artifacts even if fail
+        uses: actions/upload-artifact@v2
+        with:
+          name: PyPi_Install_Linux_python_${{ matrix.python-version }}
+          path: pypi_install_linux_artifacts_python_${{ matrix.python-version }}

--- a/test_files/tests.sh
+++ b/test_files/tests.sh
@@ -3,7 +3,8 @@
 # Note that you may need to change the $cfchecker variable in this file to
 # point to the full path location of your "cfchecks" script
 
-outdir=tests_output.$$
+# as with cache dir below, best to put it in /tmp since we dont want ani git orphan files
+outdir=/tmp/cfchecker/tests_output
 mkdir $outdir
 
 std_name_table=http://cfconventions.org/Data/cf-standard-names/current/src/cf-standard-name-table.xml
@@ -13,10 +14,13 @@ cfchecker="cfchecks"
 
 failed=0
 
-echo "Unzipping input netcdf files..."
-gzip -d *.gz
+# no gz files so this fails
+# echo "Unzipping input netcdf files..."
+# gzip -d *.gz
 
-cache_opts="-x --cache_dir /home/ros/temp/cfcache-files-py3"
+# this is a better location since we don't want to add any git orpah files
+mkdir /tmp/cfchecker
+cache_opts="-x --cache_dir /tmp/cfchecker"
 
 for file in `ls *.nc`
 do

--- a/test_files/tests.sh
+++ b/test_files/tests.sh
@@ -14,7 +14,7 @@ cfchecker="cfchecks"
 
 failed=0
 
-# no gz files so this fails
+# no gz files so this fails if not run from here
 # echo "Unzipping input netcdf files..."
 # gzip -d *.gz
 


### PR DESCRIPTION
Hey @RosalynHatcher hope you don't mind me nosing a bit here :grin: I wrote a quick Github Actions test flow for you (with some explanations in comments) so you can test the installation from PyPi; you can write a similar one to test the install from source, for developers. A few notes from me:

- tfunctional testing can be improved, be careful that the current test script fails if you don't create the cache dir in a user-accessible location, also it'd be good to put those target dirs outside the git-controlled repo, so you don't create orphan files
- the nc files that the tests use get modified in-place so that's not good since they're git-controlled

Another side-note, `cfchecks --version` returns the help docstring but not the version, I think you are not setting it correctly at argparse stage, sorry, am nagging too much :grin: 

There is also an issue I wanted to flag: it's best you recommend users+developers (the advanced users) to install it in a virt env (either Python or Conda virt env), a la:

```
conda create -n cfchecker
conda install pip
conda install -c conda-forge udunits2  # this is a runaway dependency that doesn't get installed with pip install -e .
pip install -e .
```

This is better and more secure than `python setup.py install`

Anyways, hope this is useful :beer: 