### PR TITLE
Bounds checks

### DIFF
--- a/src/cfchecker/cfchecks.py
+++ b/src/cfchecker/cfchecks.py
@@ -2159,9 +2159,16 @@ class CFChecker(object):
             usesLen = len(uses)
             i = 1
             for use in uses:
-                if use == "C" and varName in allCoordVars:
-                    # Valid association
-                    break
+                if use == "C":
+                    if self.version < vn1_7:
+                        if varName in allCoordVars:
+                            # Valid association
+                            break
+                    else:
+                        # Allow for formula_terms attribute in boundary variables
+                        if varName in allCoordVars or varName in boundsVars:
+                            # Valid association
+                            break
                 elif use == "D" and varName not in allCoordVars:
                     # Valid association
                     break

--- a/src/cfchecker/cfchecks.py
+++ b/src/cfchecker/cfchecks.py
@@ -48,6 +48,8 @@ from __future__ import print_function
 from builtins import str
 from builtins import next
 from builtins import map
+
+import numpy as np
 from past.builtins import basestring
 from builtins import object
 
@@ -776,7 +778,7 @@ class CFChecker(object):
             self.chkDescription(var)
 
             for attribute in map(str, self.f.variables[var].ncattrs()):
-                self.chkAttribute(attribute, var, allCoordVars, geometryContainerVars)
+                self.chkAttribute(attribute, var, allCoordVars, boundsVars, geometryContainerVars)
 
             self.chkUnits(var, allCoordVars)
             self.chkValidMinMaxRange(var)
@@ -785,7 +787,7 @@ class CFChecker(object):
             self.chkPositiveAttribute(var)
             self.chkCellMethods(var)
             self.chkCellMeasures(var)
-            self.chkFormulaTerms(var, allCoordVars)
+            self.chkFormulaTerms(var, allCoordVars, boundsVars)
             self.chkCompressAttr(var)
             self.chkPackedData(var)
 
@@ -2073,7 +2075,7 @@ class CFChecker(object):
           
         return typecode
 
-    def chkAttribute(self, attribute, varName, allCoordVars, geometryContainerVars):
+    def chkAttribute(self, attribute, varName, allCoordVars, boundsVars, geometryContainerVars):
         """Check the syntax of the attribute name, that the attribute
         is of the correct type and that it is attached to the right
         kind of variable."""
@@ -2434,7 +2436,7 @@ class CFChecker(object):
                 except StopIteration:
                     pass
 
-    def chkFormulaTerms(self, varName, allCoordVars):
+    def chkFormulaTerms(self, varName, allCoordVars, boundsVars):
         """Checks on formula_terms attribute (CF Section 4.3.3):
         formula_terms = var: term var: term ...
         1) No standard_name present
@@ -2451,16 +2453,42 @@ class CFChecker(object):
             else:
                 scode = "4.3.2"
 
+            bounds_parent = None
             if varName not in allCoordVars:
-                self._add_error("formula_terms attribute only allowed on coordinate variables", varName, code=scode)
+                if self.version < vn1_7:
+                    self._add_error("formula_terms attribute only allowed on coordinate variables", varName, code=scode)
+                else:
+                    if varName not in boundsVars:
+                        self._add_error("formula_terms attribute only allowed on coordinate variables and associated "
+                                        "boundary variables", varName, code=scode)
+                    else:
+                        for var_name, var_data in self.f.variables.items():
+                            if hasattr(var_data, 'bounds'):
+                                if var_data.bounds == varName:
+                                    bounds_parent = var_data
+
+            # Check for consistency between bounds and parent coordinate variable
+            if bounds_parent:
+                for attr_common in ['units', 'standard_name', 'axis', 'positive', 'calendar',
+                                    'leap_month', 'leap_year']:
+                    if hasattr(var, attr_common) and hasattr(bounds_parent, attr_common):
+                        self._add_warn("Duplicate entries of variable attribute " + attr_common +
+                                       "in coordinate and associated boundary variable", varName, code="7.1")
+                        if var.ncattr[attr_common] == bounds_parent.ncattr[attr_common]:
+                            self._add_error("Variable attribute " + attr_common +
+                                            " does not agree between coordinate and associated boundary variable",
+                                            varName, code='7.1')
 
             # Get standard_name to determine which formula is to be used
-            if not hasattr(var, 'standard_name'):
+            if not hasattr(var, 'standard_name') and not hasattr(bounds_parent, 'standard_name'):
                 self._add_error("Cannot get formula definition as no standard_name", varName, code=scode)
                 # No sense in carrying on as can't validate formula_terms without valid standard name
                 return
 
-            (stdName, modifier) = self.getStdName(var)
+            if hasattr(var, 'standard_name'):
+                (stdName, modifier) = self.getStdName(var)
+            else:
+                (stdName, modifier) = self.getStdName(bounds_parent)
 
             if stdName not in self.alias:
                 self._add_error("No formula defined for standard name: %s" % stdName, varName, code=scode)
@@ -2549,6 +2577,44 @@ class CFChecker(object):
 
                     except StopIteration:
                         break
+
+            # Check conformity of formula_terms in boundary coordinate variable
+            if hasattr(var, 'bounds'):
+                var_bounds = self.f.variables[var.bounds]
+                if not hasattr(var_bounds, 'formula_terms'):
+                    self._add_error("formula_terms attribute not present in boundary variable", varName, code=7.1)
+                else:
+                    formulaTerms_bounds = var_bounds.formula_terms
+                    ft_dict = {}
+                    for nft, ft in enumerate([formulaTerms, formulaTerms_bounds]):
+                        ft_dict[nft] = {}
+                        ft_dict[nft]['term'], ft_dict[nft]['variable'] = [], []
+                        for element in ft.split(' '):
+                            if element.endswith(':'):
+                                ft_dict[nft]['term'].append(element.rstrip(':'))
+                            else:
+                                ft_dict[nft]['variable'].append(element)
+
+                    if ft_dict[0]['term'] != ft_dict[1]['term']:
+                        self._add_error("Terms in formula_terms attribute vary between coordinate "
+                                        "and associated boundary variable", varName, code=7.1)
+
+                    for n_term_var, term_var in enumerate(ft_dict[0]['variable']):
+                        term_var_dim = self.f.variables[term_var].dimensions
+                        for dim_term in term_var_dim:
+                            if hasattr(self.f.variables[dim_term], 'positive'):
+                                term_interp = self.getInterpretation(self.f.variables[dim_term].units,
+                                                                     self.f.variables[dim_term].positive)
+                            else:
+                                term_interp = self.getInterpretation(self.f.variables[dim_term].units)
+                            if term_interp == "Z":
+                                term_var_dim_bound = self.f.variables[ft_dict[1]['variable'][n_term_var]].dimensions
+                                if len(term_var_dim_bound) != len(term_var_dim)+1:
+                                    self._add_error("Variable depending on vertical dimension in the formula_terms "
+                                                    "attribute in the coordinate and associated boundary variable have "
+                                                    "same dimensionality", varName, code=7.1)
+                                else:
+                                    break
 
     def chkUnits(self, varName, allCoordVars):
         """Check units attribute"""


### PR DESCRIPTION
Resolves #75 

We have been using the CF Checker as part of the [ATMODAT Standard Compliance Checker](https://github.com/AtMoDat/atmodat_data_checker) and frequently ran into an issue where the CF Checker reported an error regarding the `formula_terms` attribute in a boundary variable of a coordinate variable. Such an error should not occur for datasets compliant with CF-1.7 or greater, as there, it is actually required for a  boundary variable to have a `formula_terms` attribute if the `formula_terms` attribute is present in the associated coordinate variable.
I drafted a PR that contains the necessary modifications for the CF Checker to correctly process boundary variables. The following has been added:

- Do not report an error/info if a boundary variable contains a `formula_terms` attribute for CF-1.7 or greater
- Identify coordinate variable (which here I will call parent) of associated boundary variable (which here I will call bound)
- Consistency check between bound and parent variable attributes. It is checked whether common variable attributes ('units', 'standard_name', 'axis', 'positive', 'calendar', 'leap_month', 'leap_year') are present in both. If so, verify that their respective entries do agree between bound and parent. Furthermore, a warning (maybe an info would be sufficient as well) is emitted in case of duplicate entries in parent and bound, as boundary variable attributes can be inherited from the parent variable
- Use `standard_name` of parent variable in case it is not present in the boundary variable to check for the formula that is defined via the `standard_name`
- Checks for conformity of `formula_terms` between parent and bound:
-`formula_terms` attribute has to be present in the boundary variable
-Terms in the `formula_terms` attribute have to be identical between parent and bound
-Verify dimension of variables in `formula_terms` that depend on vertical dimension have a trailing dimension

Something that hasn't been added yet is to allow for parametric coordinate variables to have a `bounds` attribute (see example 7.1)

Maybe you can have a look at my modification. I haven't added any tests for these changes yet.