### PR TITLE
Make test script more portable and ignore output files

### DIFF
--- a/test_files/.gitignore
+++ b/test_files/.gitignore
@@ -1,0 +1,3 @@
+*.nc
+tests_output*
+cfcache-files-py3/

--- a/test_files/tests.sh
+++ b/test_files/tests.sh
@@ -6,6 +6,8 @@
 outdir=tests_output.$$
 mkdir $outdir
 
+# Pin the tables, as the tests fail if they differ.
+# This can be unpinned in future MRs updating the tests.
 std_name_table=https://cfconventions.org/Data/cf-standard-names/79/src/cf-standard-name-table.xml
 area_table=https://cfconventions.org/Data/area-type-table/10/src/area-type-table.xml
 

--- a/test_files/tests.sh
+++ b/test_files/tests.sh
@@ -7,7 +7,7 @@ outdir=tests_output.$$
 mkdir $outdir
 
 std_name_table=https://cfconventions.org/Data/cf-standard-names/79/src/cf-standard-name-table.xml
-area_table=http://cfconventions.org/Data/area-type-table/10/src/area-type-table.xml
+area_table=https://cfconventions.org/Data/area-type-table/10/src/area-type-table.xml
 
 
 cfchecker=$(which cfchecks)
@@ -50,10 +50,8 @@ do
     echo $file: Success
     rm $outdir/$file.out
   else
-    diff $outdir/$file.out $result
     echo $file: Failed
     failed=`expr $failed + 1`
-    exit 1
   fi
 done
 

--- a/test_files/tests.sh
+++ b/test_files/tests.sh
@@ -6,17 +6,19 @@
 outdir=tests_output.$$
 mkdir $outdir
 
-std_name_table=http://cfconventions.org/Data/cf-standard-names/current/src/cf-standard-name-table.xml
-area_table=http://cfconventions.org/Data/area-type-table/current/src/area-type-table.xml
+std_name_table=https://cfconventions.org/Data/cf-standard-names/79/src/cf-standard-name-table.xml
+area_table=http://cfconventions.org/Data/area-type-table/10/src/area-type-table.xml
 
-cfchecker="cfchecks"
+
+cfchecker=$(which cfchecks)
 
 failed=0
 
 echo "Unzipping input netcdf files..."
 gzip -d *.gz
 
-cache_opts="-x --cache_dir /home/ros/temp/cfcache-files-py3"
+mkdir -p cfcache-files-py3
+cache_opts="-x --cache_dir ./cfcache-files-py3"
 
 for file in `ls *.nc`
 do
@@ -37,7 +39,7 @@ do
     $cfchecker $cache_opts -s $std_name_table -v 1.0 $file > $outdir/$file.out 2>&1
   else
     # Run checker using the CF version specified in the conventions attribute of the file
-    $cfchecker $cache_opts -s $std_name_table -v auto $file > $outdir/$file.out 2>&1
+    $cfchecker $cache_opts -s $std_name_table -a $area_table -v auto $file > $outdir/$file.out 2>&1
   fi
 
   # Check the output against what is expected
@@ -48,8 +50,10 @@ do
     echo $file: Success
     rm $outdir/$file.out
   else
+    diff $outdir/$file.out $result
     echo $file: Failed
     failed=`expr $failed + 1`
+    exit 1
   fi
 done
 


### PR DESCRIPTION
Hi there,

Thanks for your work on the cf-checker. I am working on a fix to #110. In order to make that sensible, I needed to get the tests passing first. I think the changes here don't break anything, but do make the tests run again in a more portable way. Happy to make any changes you'd like!